### PR TITLE
Use built files instead of entire git repo.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,7 @@
     "tests"
   ],
   "dependencies": {
-    "threejs": "r82",
+    "threejs": "https://raw.githubusercontent.com/mrdoob/three.js/r97/build/three.min.js",
     "purescript-foreign": "~5.0.0",
     "purescript-web-dom": "^1.0.0",
     "purescript-easy-ffi": "~2.1.0",

--- a/examples/resources/circleToSquare.html
+++ b/examples/resources/circleToSquare.html
@@ -14,7 +14,7 @@
 <body>
     <div id="container"></div>
 
-    <script src="../bower_components/threejs/build/three.js"></script>
+    <script src="../bower_components/threejs/index.js"></script>
     <script src="../output/circleToSquare.js"></script>
 </body>
 </html>

--- a/examples/resources/lineArray.html
+++ b/examples/resources/lineArray.html
@@ -14,7 +14,7 @@
 <body>
     <div id="container"></div>
 
-    <script src="../bower_components/threejs/build/three.js"></script>
+    <script src="../bower_components/threejs/index.js"></script>
     <script src="../output/lineArray.js"></script>
 </body>
 </html>

--- a/examples/resources/motionStretch.html
+++ b/examples/resources/motionStretch.html
@@ -18,7 +18,7 @@
 <body>
     <div id="container"></div>
 
-    <script src="../bower_components/threejs/build/three.js"></script>
+    <script src="../bower_components/threejs/index.js"></script>
     <script src="../output/motionStretch.js"></script>
 </body>
 </html>

--- a/examples/resources/simpleCube.html
+++ b/examples/resources/simpleCube.html
@@ -14,7 +14,7 @@
 <body>
     <div id="container"></div>
 
-    <script src="../bower_components/threejs/build/three.js"></script>
+    <script src="../bower_components/threejs/index.js"></script>
     <script src="../output/simpleCube.js"></script>
 </body>
 </html>

--- a/examples/resources/simpleLine.html
+++ b/examples/resources/simpleLine.html
@@ -14,7 +14,7 @@
 <body>
     <div id="container"></div>
 
-    <script src="../bower_components/threejs/build/three.js"></script>
+    <script src="../bower_components/threejs/index.js"></script>
     <script src="../output/simpleLine.js"></script>
 </body>
 </html>


### PR DESCRIPTION
This uses the pre-minified version of threejs
This causes bower install to finish much faster,
as threejs repo is quite large and can take
a long time to download.

Also uses the latest revision of threejs